### PR TITLE
Fixed cudatoolkit version string

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
 
 requirements:
   run:
-    - cudatoolkit {{ cuda_version }}
+    - cudatoolkit {{ cudatoolkit }}
 
 source:
   - url: https://developer.download.nvidia.com/compute/machine-learning/repos/rhel7/ppc64le/libcudnn{{ cudnn_version.split('.')[0] }}-devel-{{ cudnn_version }}.cuda{{ cuda_version }}.ppc64le.rpm # [ppc64le]


### PR DESCRIPTION
Fixed cuda version of the cudatoolkit package in run dependency section. It is needed to be consistent with all the packages that depend on `10.2.*` and not `10.2`